### PR TITLE
Added type casting

### DIFF
--- a/openean/OpenEAN.py
+++ b/openean/OpenEAN.py
@@ -12,7 +12,7 @@ class OpenEAN:
     def request(self, ean):
         """only does request and returns raw text response doesn't check anything like error code in content"""
 
-        url = base_url + "&queryid=" + self.userID + "&ean=" + ean
+        url = base_url + "&queryid=" + str(self.userID) + "&ean=" + str(ean)
         r = requests.get(url)
 
         content = r.content


### PR DESCRIPTION
All inputs by the user have to be type casted onto Strings so they can be concatenated with other Strings.

This also has to be that way in order for the example under "Getting started" to work.
If you do not want to accept this Pull request, shouldn't the example be changed in order to work?